### PR TITLE
Simplify BASEDIR variable

### DIFF
--- a/build-unmount.sh
+++ b/build-unmount.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BASEDIR="`cd $0 >/dev/null 2>&1; pwd`" >/dev/null 2>&1
+BASEDIR="pwd"
 
 mountpoints=`mount | grep ${BASEDIR} | awk '{print $3}' | awk {'print length, $1'} | sort -g -r | cut -d' ' -f2-`
 


### PR DESCRIPTION
I've been reading through the build scripts to try and figure out how to build Crankshaft and I've come across something in one of the scripts that doesn't make sense to me.

https://github.com/opencardev/crankshaft/blob/6b8a704a7cd07a33099ad810095532315befa1cf/build-unmount.sh#L3

I believe this script is trying to see if there are mounted volumes inside the directory that this script is run in and the `BASEDIR` variable is storing the absolute path of that directory. However, I don't understand what

```sh
cd $0 >/dev/null 2>&1;
```
is supposed to achieve. According to [this](https://www.tldp.org/LDP/abs/html/othertypesv.html) documentation, `$0` always refers to the name of the running script. That is to say that if run:
```sh
#!/binbash
# some_script.sh
echo $0
exit 0
```
It would output:
```sh
./some_script.sh
```
And because this is the relative path to a file, I would get an error if I tried to `cd` into it like this:
```sh
$ cd ./some_script.sh
-bash: cd: ./some_script: Not a directory
```
Also, I see that all output from stdout and stderr is being redirected to `/dev/null` which would mean that
```sh
cd $0 >/dev/null 2>&1;
```
will always return an empty string. 

Because of inability to `cd` into a file and the creation of an empty string, I think using the `pwd` command would achieve the same outcome with simpler code.