### PR TITLE
Changed path to check if the headunit got a dhcp lease

### DIFF
--- a/stage3/03-crankshaft-base/files/opt/crankshaft/service_wpachange.sh
+++ b/stage3/03-crankshaft-base/files/opt/crankshaft/service_wpachange.sh
@@ -18,7 +18,7 @@ function update_network() {
         COUNTER=0
         #check for 30 seconds for dhcp lease assigned
         while [ $COUNTER -lt 30 ]; do
-            if [ -f /var/run/dhcpcd/resolv.conf/wlan0.dhcp ]; then
+            if [ -f /var/run/resolvconf/interfaces/wlan0.dhcp ]; then
                 echo "[${CYAN}${BOLD} INFO ${RESET}] *******************************************************" >/dev/tty3
                 echo "[${CYAN}${BOLD} INFO ${RESET}] DHCP-EVENT: $SSID got a lease" >/dev/tty3
                 echo "[${CYAN}${BOLD} INFO ${RESET}] *******************************************************" >/dev/tty3


### PR DESCRIPTION
Changed the path to check if the user got a dhcp lease.
This should fix problems to start AA on the headunit when running it in Client mode.
Should fix #443 