### PR TITLE
Fix lightsensor.service unable to change brightness (#515)

### DIFF
--- a/stage3/03-crankshaft-base/files/opt/crankshaft/service_lightsensor.py
+++ b/stage3/03-crankshaft-base/files/opt/crankshaft/service_lightsensor.py
@@ -106,27 +106,27 @@ while True:
         # Set display brightness
         if Luxrounded <= int(get_var('LUX_LEVEL_1')):
             os.system("crankshaft brightness set " +
-                      str(get_var('DISP_BRIGHTNESS_1')) + " &")
+                      str(int(get_var('DISP_BRIGHTNESS_1'))) + " &")
             step = 1
         elif Luxrounded > int(get_var('LUX_LEVEL_1')) and Luxrounded < int(get_var('LUX_LEVEL_2')):
             os.system("crankshaft brightness set " +
-                      str(get_var('DISP_BRIGHTNESS_2')) + " &")
+                      str(int(get_var('DISP_BRIGHTNESS_2'))) + " &")
             step = 2
         elif Luxrounded >= int(get_var('LUX_LEVEL_2')) and Luxrounded < int(get_var('LUX_LEVEL_3')):
             os.system("crankshaft brightness set " +
-                      str(get_var('DISP_BRIGHTNESS_3')) + " &")
+                      str(int(get_var('DISP_BRIGHTNESS_3'))) + " &")
             step = 3
         elif Luxrounded >= int(get_var('LUX_LEVEL_3')) and Luxrounded < int(get_var('LUX_LEVEL_4')):
             os.system("crankshaft brightness set " +
-                      str(get_var('DISP_BRIGHTNESS_4')) + " &")
+                      str(int(get_var('DISP_BRIGHTNESS_4'))) + " &")
             step = 4
         elif Luxrounded >= int(get_var('LUX_LEVEL_4')) and Luxrounded < int(get_var('LUX_LEVEL_5')):
             os.system("crankshaft brightness set " +
-                      str(get_var('DISP_BRIGHTNESS_5')) + " &")
+                      str(int(get_var('DISP_BRIGHTNESS_5'))) + " &")
             step = 5
         elif Luxrounded >= int(get_var('LUX_LEVEL_5')):
             os.system("crankshaft brightness set " +
-                      str(get_var('DISP_BRIGHTNESS_5')) + " &")
+                      str(int(get_var('DISP_BRIGHTNESS_5'))) + " &")
             step = 6
 
         if daynight_gpio == 0:


### PR DESCRIPTION
As described in my comments in #515, `get_var` function returns all values incorrectly.

This PR fixes that behaviour by converting the function's output to INT, then back to STRING where needed.
This way the command that lightsensor.service sends to crankshaft cli includes properly formatted value.

Tested by editing /opt/crankshaft/service_lightsensor.py on latest installation (v2022.09.12.1) with sudo nano via SSH.
During my tests, system changed brightness in response to sensor readings.
My setup is Raspberry Pi 3B+ and TSL25911 (TSL2591 equivalent).

My changes do not touch code related to sensor reading, but only the part sending the command to change brightness, so it should work independently of sensor used.