### PR TITLE
Added Pi Zero 2w boot options #754

### DIFF
--- a/stage3/03-crankshaft-base/files/boot/config.txt
+++ b/stage3/03-crankshaft-base/files/boot/config.txt
@@ -73,6 +73,11 @@ dtoverlay=vc4-fkms-v3d
 # GPU Mem
 gpu_mem=128
 
+[pi02]
+dtoverlay=vc4-fkms-v3d
+# GPU Mem
+gpu_mem=128
+
 [pi4]
 # Enable DRM VC4 V3D driver on top of the dispmanx display stack
 dtoverlay=vc4-fkms-v3d


### PR DESCRIPTION
As described in the issue #754, I can't use the image with a Pi Zero 2w.
I suggest adding the following options in the config.txt of the Pi image.